### PR TITLE
Integrate cargo features: dlopen and egl

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,3 +8,10 @@ rust:
 os:
   - linux
 
+before_install:
+    - sudo apt-get update -qq
+    - sudo apt-get install -qq libwayland-client0 libwayland-egl1-mesa
+
+script:
+    - cargo test --features "egl"
+    - cargo test --features "dlopen egl"

--- a/.travis.yml
+++ b/.travis.yml
@@ -8,10 +8,5 @@ rust:
 os:
   - linux
 
-before_install:
-    - sudo apt-get update -qq
-    - sudo apt-get install -qq libwayland-client0 libwayland-egl1-mesa
-
 script:
-    - cargo test --features "egl"
     - cargo test --features "dlopen egl"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,3 +14,6 @@ lazy_static = "0.1"
 
 [dev-dependencies]
 byteorder = "0.3"
+
+[features]
+egl = []

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,4 +16,5 @@ lazy_static = "0.1"
 byteorder = "0.3"
 
 [features]
+dlopen = []
 egl = []

--- a/examples/simple-connect.rs
+++ b/examples/simple-connect.rs
@@ -11,9 +11,7 @@ use wayland::core::ShmFormat;
 
 fn main() {
 
-    assert!(wayland::is_wayland_lib_available(), "Wayland library could not be found.");
-
-    let display = default_display().expect("Unable to connect to Wayland server.");
+    let display = default_display().expect("Unable to connect to a Wayland server.");
 
     let registry = display.get_registry();
     display.sync_roundtrip();

--- a/src/core/compositor.rs
+++ b/src/core/compositor.rs
@@ -36,8 +36,11 @@ impl Compositor {
 }
 
 impl Bind<Registry> for Compositor {
+
     fn interface() -> &'static abi::wl_interface {
-        abi::WAYLAND_CLIENT_HANDLE.wl_compositor_interface
+        #[cfg(feature = "dlopen")] use ffi::abi::WAYLAND_CLIENT_HANDLE;
+        #[cfg(not(feature = "dlopen"))] use ffi::abi::wl_compositor_interface;
+        ffi_dispatch_static!(WAYLAND_CLIENT_HANDLE, wl_compositor_interface)
     }
 
     unsafe fn wrap(ptr: *mut wl_compositor, registry: Registry) -> Compositor {

--- a/src/core/mod.rs
+++ b/src/core/mod.rs
@@ -19,14 +19,14 @@ pub use self::subcompositor::SubCompositor;
 pub use self::subsurface::SubSurface;
 pub use self::surface::{Surface, WSurface, SurfaceId};
 
-pub use self::keyboard::KeymapFormat as KeymapFormat;
-pub use self::keyboard::KeyState as KeyState;
-pub use self::pointer::ScrollAxis as ScrollAxis;
-pub use self::pointer::ButtonState as ButtonState;
-pub use self::output::OutputTransform as OutputTransform;
-pub use self::output::OutputSubpixel as OutputSubpixel;
-pub use self::shell_surface::ShellSurfaceResize as ShellSurfaceResize;
-pub use self::shm::ShmFormat as ShmFormat;
+pub use self::keyboard::KeymapFormat;
+pub use self::keyboard::KeyState;
+pub use self::pointer::ScrollAxis;
+pub use self::pointer::ButtonState;
+pub use self::output::OutputTransform;
+pub use self::output::OutputSubpixel;
+pub use self::shell_surface::ShellSurfaceResize;
+pub use self::shm::ShmFormat;
 
 mod buffer;
 mod compositor;

--- a/src/core/output.rs
+++ b/src/core/output.rs
@@ -197,8 +197,11 @@ impl Output {
 }
 
 impl Bind<Registry> for Output {
+
     fn interface() -> &'static abi::wl_interface {
-        abi::WAYLAND_CLIENT_HANDLE.wl_output_interface
+        #[cfg(feature = "dlopen")] use ffi::abi::WAYLAND_CLIENT_HANDLE;
+        #[cfg(not(feature = "dlopen"))] use ffi::abi::wl_output_interface;
+        ffi_dispatch_static!(WAYLAND_CLIENT_HANDLE, wl_output_interface)
     }
 
     unsafe fn wrap(ptr: *mut wl_output, registry: Registry) -> Output {

--- a/src/core/seat.rs
+++ b/src/core/seat.rs
@@ -114,8 +114,11 @@ impl Seat {
 
 
 impl Bind<Registry> for Seat {
+
     fn interface() -> &'static abi::wl_interface {
-        abi::WAYLAND_CLIENT_HANDLE.wl_seat_interface
+        #[cfg(feature = "dlopen")] use ffi::abi::WAYLAND_CLIENT_HANDLE;
+        #[cfg(not(feature = "dlopen"))] use ffi::abi::wl_seat_interface;
+        ffi_dispatch_static!(WAYLAND_CLIENT_HANDLE, wl_seat_interface)
     }
 
     unsafe fn wrap(ptr: *mut wl_seat, registry: Registry) -> Seat {

--- a/src/core/shell.rs
+++ b/src/core/shell.rs
@@ -39,7 +39,9 @@ impl Shell {
 
 impl Bind<Registry> for Shell {
     fn interface() -> &'static abi::wl_interface {
-        abi::WAYLAND_CLIENT_HANDLE.wl_shell_interface
+        #[cfg(feature = "dlopen")] use ffi::abi::WAYLAND_CLIENT_HANDLE;
+        #[cfg(not(feature = "dlopen"))] use ffi::abi::wl_shell_interface;
+        ffi_dispatch_static!(WAYLAND_CLIENT_HANDLE, wl_shell_interface)
     }
 
     unsafe fn wrap(ptr: *mut wl_shell, registry: Registry) -> Shell {

--- a/src/core/shm.rs
+++ b/src/core/shm.rs
@@ -47,8 +47,11 @@ impl Shm {
 }
 
 impl Bind<Registry> for Shm {
+
     fn interface() -> &'static abi::wl_interface {
-        abi::WAYLAND_CLIENT_HANDLE.wl_shm_interface
+        #[cfg(feature = "dlopen")] use ffi::abi::WAYLAND_CLIENT_HANDLE;
+        #[cfg(not(feature = "dlopen"))] use ffi::abi::wl_shm_interface;
+        ffi_dispatch_static!(WAYLAND_CLIENT_HANDLE, wl_shm_interface)
     }
 
     unsafe fn wrap(ptr: *mut wl_shm, registry: Registry) -> Shm {

--- a/src/core/subcompositor.rs
+++ b/src/core/subcompositor.rs
@@ -43,8 +43,11 @@ impl Drop for InternalSubCompositor {
 }
 
 impl Bind<Registry> for SubCompositor {
+
     fn interface() -> &'static abi::wl_interface {
-        abi::WAYLAND_CLIENT_HANDLE.wl_subcompositor_interface
+        #[cfg(feature = "dlopen")] use ffi::abi::WAYLAND_CLIENT_HANDLE;
+        #[cfg(not(feature = "dlopen"))] use ffi::abi::wl_subcompositor_interface;
+        ffi_dispatch_static!(WAYLAND_CLIENT_HANDLE, wl_subcompositor_interface)
     }
 
     unsafe fn wrap(ptr: *mut wl_subcompositor, registry: Registry) -> SubCompositor {

--- a/src/ffi/abi.rs
+++ b/src/ffi/abi.rs
@@ -60,6 +60,7 @@ pub fn wl_fixed_from_double(d: f64) -> wl_fixed_t {
     (d * 256.) as i32
 }
 
+#[cfg(feature = "dlopen")]
 external_library!(WaylandClient,
     // interfaces
     wl_buffer_interface: &'static wl_interface,
@@ -184,6 +185,7 @@ external_library!(WaylandClient,
     wl_array_copy: unsafe extern fn(array: *mut wl_array, source: *mut wl_array)
 );
 
+#[cfg(feature = "dlopen")]
 lazy_static!(
     pub static ref WAYLAND_CLIENT_OPTION: Option<WaylandClient> = { 
         WaylandClient::open("libwayland-client.so")
@@ -192,3 +194,128 @@ lazy_static!(
         WAYLAND_CLIENT_OPTION.as_ref().expect("Library libwayland-client.so could not be loaded.")
     };
 );
+
+#[cfg(not(feature = "dlopen"))]
+#[link(name = "wayland-client")]
+extern {
+    pub static wl_buffer_interface: wl_interface;
+    pub static wl_callback_interface: wl_interface;
+    pub static wl_compositor_interface: wl_interface;
+    pub static wl_data_device_interface: wl_interface;
+    pub static wl_data_device_manager_interface: wl_interface;
+    pub static wl_data_offer_interface: wl_interface;
+    pub static wl_data_source_interface: wl_interface;
+    pub static wl_display_interface: wl_interface;
+    pub static wl_keyboard_interface: wl_interface;
+    pub static wl_output_interface: wl_interface;
+    pub static wl_pointer_interface: wl_interface;
+    pub static wl_region_interface: wl_interface;
+    pub static wl_registry_interface: wl_interface;
+    pub static wl_seat_interface: wl_interface;
+    pub static wl_shell_interface: wl_interface;
+    pub static wl_shell_surface_interface: wl_interface;
+    pub static wl_shm_interface: wl_interface;
+    pub static wl_shm_pool_interface: wl_interface;
+    pub static wl_subcompositor_interface: wl_interface;
+    pub static wl_subsurface_interface: wl_interface;
+    pub static wl_surface_interface: wl_interface;
+    pub static wl_touch_interface: wl_interface;
+
+    // display creation and destruction
+    pub fn wl_display_connect_to_fd(fd: c_int) -> *mut wl_display;
+    pub fn wl_display_connect(name: *const c_char) -> *mut wl_display;
+    pub fn wl_display_disconnect(display: *mut wl_display);
+    pub fn wl_display_get_fd(display: *mut wl_display) -> c_int;
+    // display events handling
+    pub fn wl_display_roundtrip(display: *mut wl_display) -> c_int;
+    pub fn wl_display_read_events(display: *mut wl_display) -> c_int;
+    pub fn wl_display_prepare_read(display: *mut wl_display) -> c_int;
+    pub fn wl_display_cancel_read(display: *mut wl_display);
+    pub fn wl_display_dispatch(display: *mut wl_display) -> c_int;
+    pub fn wl_display_dispatch_pending(display: *mut wl_display) -> c_int;
+    // error handling
+    pub fn wl_display_get_error(display: *mut wl_display) -> c_int;
+    pub fn wl_display_get_protocol_error(display: *mut wl_display,
+                                                    interface: *mut *mut wl_interface,
+                                                    id: *mut uint32_t
+                                                   ) -> uint32_t;
+    // requests handling
+    pub fn wl_display_flush(display: *mut wl_display) -> c_int;
+
+    // event queues
+    pub fn wl_event_queue_destroy(queue: *mut wl_event_queue);
+    pub fn wl_display_create_queue(display: *mut wl_display) -> *mut wl_event_queue;
+    pub fn wl_display_roundtrip_queue(display: *mut wl_display,
+                                                 queue: *mut wl_event_queue
+                                                ) -> c_int;
+    pub fn wl_display_prepare_read_queue(display: *mut wl_display,
+                                                    queue: *mut wl_event_queue
+                                                   ) -> c_int;
+    pub fn wl_display_dispatch_queue(display: *mut wl_display,
+                                                queue: *mut wl_event_queue
+                                               ) -> c_int;
+    pub fn wl_display_dispatch_queue_pending(display: *mut wl_display,
+                                                        queue: *mut wl_event_queue
+                                                       ) -> c_int;
+
+    // proxys
+    pub fn wl_proxy_create(factory: *mut wl_proxy,
+                                      interface: *const wl_interface
+                                     ) -> *mut wl_proxy;
+    pub fn wl_proxy_destroy(proxy: *mut wl_proxy);
+    pub fn wl_proxy_add_listener(proxy: *mut wl_proxy,
+                                            implementation: *mut extern fn(),
+                                            data: *mut c_void
+                                           ) -> c_int;
+    pub fn wl_proxy_get_listener(proxy: *mut wl_proxy) -> *const c_void;
+    pub fn wl_proxy_add_dispatcher(proxy: *mut wl_proxy,
+                                              dispatcher: wl_dispatcher_func_t,
+                                              implementation: *const c_void,
+                                              data: *mut c_void
+                                             ) -> c_int;
+    pub fn wl_proxy_marshal_array_constructor(proxy: *mut wl_proxy,
+                                                         opcode: uint32_t,
+                                                         args: *mut wl_argument,
+                                                         interface: *const wl_interface
+                                                        ) -> c_int;
+    pub fn wl_proxy_marshal(proxy: *mut wl_proxy,
+                                       opcode: uint32_t,
+                                       ...
+                                      );
+    pub fn wl_proxy_marshal_constructor(proxy: *mut wl_proxy,
+                                                   opcode: uint32_t,
+                                                   interface: *const wl_interface,
+                                                   ...
+                                                  ) -> *mut wl_proxy;
+    pub fn wl_proxy_marshal_array(proxy: *mut wl_proxy,
+                                             opcode: uint32_t,
+                                             args: *mut wl_argument
+                                            );
+    pub fn wl_proxy_set_user_data(proxy: *mut wl_proxy,
+                                             data: *mut c_void
+                                            );
+    pub fn wl_proxy_get_user_data(proxy: *mut wl_proxy) -> *mut c_void;
+    pub fn wl_proxy_get_id(proxy: *mut wl_proxy) -> uint32_t;
+    pub fn wl_proxy_get_class(proxy: *mut wl_proxy) -> *const c_char;
+    pub fn wl_proxy_set_queue(proxy: *mut wl_proxy,
+                                         queue: *mut wl_event_queue
+                                        );
+
+    // log
+    pub fn wl_log_set_handler_client(handler: wl_log_func_t);
+    // wl_log(fmt: *const c_char, ...);
+
+    // lists
+    pub fn wl_list_init(list: *mut wl_list);
+    pub fn wl_list_insert(list: *mut wl_list, elm: *mut wl_list);
+    pub fn wl_list_remove(elm: *mut wl_list);
+    pub fn wl_list_length(list: *const wl_list) -> c_int;
+    pub fn wl_list_empty(list: *const wl_list) -> c_int;
+    pub fn wl_list_insert_list(list: *mut wl_list, other: *mut wl_list);
+
+    // arrays
+    pub fn wl_array_init(array: *mut wl_array);
+    pub fn wl_array_release(array: *mut wl_array);
+    pub fn wl_array_add(array: *mut wl_array, size: size_t);
+    pub fn wl_array_copy(array: *mut wl_array, source: *mut wl_array);
+}

--- a/src/ffi/dlopen.rs
+++ b/src/ffi/dlopen.rs
@@ -1,3 +1,36 @@
+#[cfg(feature = "dlopen")]
+#[macro_escape]
+macro_rules! ffi_dispatch(
+    ($handle: ident, $func: ident, $($arg: expr),*) => (
+        ($handle.$func)($($arg),*)
+    )
+);
+
+#[cfg(not(feature = "dlopen"))]
+#[macro_escape]
+macro_rules! ffi_dispatch(
+    ($handle: ident, $func: ident, $($arg: expr),*) => (
+        $func($($arg),*)
+    )
+);
+
+#[cfg(feature = "dlopen")]
+#[macro_escape]
+macro_rules! ffi_dispatch_static(
+    ($handle: ident, $name: ident) => (
+        $handle.$name
+    )
+);
+
+#[cfg(not(feature = "dlopen"))]
+#[macro_escape]
+macro_rules! ffi_dispatch_static(
+    ($handle: ident, $name: ident) => (
+        &$name
+    )
+);
+
+#[cfg(feature = "dlopen")]
 #[macro_escape]
 macro_rules! external_library(
     (__struct, $structname: ident, $($name: ident: $proto: ty),+) => (

--- a/src/ffi/interfaces/buffer.rs
+++ b/src/ffi/interfaces/buffer.rs
@@ -1,6 +1,10 @@
 use libc::{c_int, c_void, uint32_t};
 
 use ffi::abi::wl_proxy;
+#[cfg(not(feature = "dlopen"))]
+use ffi::abi::{wl_proxy_destroy, wl_proxy_add_listener, wl_proxy_set_user_data,
+               wl_proxy_get_user_data, wl_proxy_marshal};
+#[cfg(feature = "dlopen")]
 use ffi::abi::WAYLAND_CLIENT_HANDLE as WCH;
 
 #[repr(C)] pub struct wl_buffer;
@@ -17,7 +21,7 @@ pub unsafe fn wl_buffer_add_listener(buffer: *mut wl_buffer,
                                      listener: *const wl_buffer_listener,
                                      data: *mut c_void
                                     ) -> c_int {
-    (WCH.wl_proxy_add_listener)(
+    ffi_dispatch!(WCH, wl_proxy_add_listener,
         buffer as *mut wl_proxy,
         listener as *mut extern fn(),
         data
@@ -26,16 +30,16 @@ pub unsafe fn wl_buffer_add_listener(buffer: *mut wl_buffer,
 
 #[inline(always)]
 pub unsafe fn wl_buffer_set_user_data(buffer: *mut wl_buffer, data: *mut c_void) {
-    (WCH.wl_proxy_set_user_data)(buffer as *mut wl_proxy, data)
+    ffi_dispatch!(WCH, wl_proxy_set_user_data, buffer as *mut wl_proxy, data)
 }
 
 #[inline(always)]
 pub unsafe fn wl_buffer_get_user_data(buffer: *mut wl_buffer) -> *mut c_void {
-    (WCH.wl_proxy_get_user_data)(buffer as *mut wl_proxy)
+    ffi_dispatch!(WCH, wl_proxy_get_user_data, buffer as *mut wl_proxy)
 }
 
 #[inline(always)]
 pub unsafe fn wl_buffer_destroy(buffer: *mut wl_buffer) {
-    (WCH.wl_proxy_marshal)(buffer as *mut wl_proxy, WL_BUFFER_DESTROY);
-    (WCH.wl_proxy_destroy)(buffer as *mut wl_proxy)
+    ffi_dispatch!(WCH, wl_proxy_marshal, buffer as *mut wl_proxy, WL_BUFFER_DESTROY);
+    ffi_dispatch!(WCH, wl_proxy_destroy, buffer as *mut wl_proxy)
 }

--- a/src/ffi/interfaces/callback.rs
+++ b/src/ffi/interfaces/callback.rs
@@ -1,6 +1,10 @@
 use libc::{c_int, c_void, uint32_t};
 
 use ffi::abi::wl_proxy;
+#[cfg(not(feature = "dlopen"))]
+use ffi::abi::{wl_proxy_destroy, wl_proxy_add_listener, wl_proxy_set_user_data,
+               wl_proxy_get_user_data};
+#[cfg(feature = "dlopen")]
 use ffi::abi::WAYLAND_CLIENT_HANDLE as WCH;
 
 #[repr(C)] pub struct wl_callback;
@@ -15,7 +19,7 @@ pub unsafe fn wl_callback_add_listener(callback: *mut wl_callback,
                                        listener: *const wl_callback_listener,
                                        data: *mut c_void
                                       ) -> c_int {
-    (WCH.wl_proxy_add_listener)(
+    ffi_dispatch!(WCH, wl_proxy_add_listener,
         callback as *mut wl_proxy,
         listener as *mut extern fn(),
         data
@@ -24,15 +28,15 @@ pub unsafe fn wl_callback_add_listener(callback: *mut wl_callback,
 
 #[inline(always)]
 pub unsafe fn wl_callback_set_user_data(callback: *mut wl_callback, user_data: *mut c_void) {
-    (WCH.wl_proxy_set_user_data)(callback as *mut wl_proxy, user_data)
+    ffi_dispatch!(WCH, wl_proxy_set_user_data, callback as *mut wl_proxy, user_data)
 }
 
 #[inline(always)]
 pub unsafe fn wl_callback_get_user_data(callback: *mut wl_callback) -> *mut c_void {
-    (WCH.wl_proxy_get_user_data)(callback as *mut wl_proxy)
+    ffi_dispatch!(WCH, wl_proxy_get_user_data, callback as *mut wl_proxy)
 }
 
 #[inline(always)]
 pub unsafe fn wl_callback_destroy(callback: *mut wl_callback) {
-    (WCH.wl_proxy_destroy)(callback as *mut wl_proxy)
+    ffi_dispatch!(WCH, wl_proxy_destroy, callback as *mut wl_proxy)
 }

--- a/src/ffi/interfaces/compositor.rs
+++ b/src/ffi/interfaces/compositor.rs
@@ -3,6 +3,10 @@ use std::ptr;
 use libc::{c_void, uint32_t};
 
 use ffi::abi::wl_proxy;
+#[cfg(not(feature = "dlopen"))]
+use ffi::abi::{wl_proxy_destroy, wl_proxy_set_user_data, wl_proxy_get_user_data,
+               wl_proxy_marshal_constructor, wl_surface_interface, wl_region_interface};
+#[cfg(feature = "dlopen")]
 use ffi::abi::WAYLAND_CLIENT_HANDLE as WCH;
 
 use super::region::wl_region;
@@ -15,35 +19,35 @@ const WL_COMPOSITOR_CREATE_REGION: uint32_t = 1;
 
 #[inline(always)]
 pub unsafe fn wl_compositor_set_user_data(compositor: *mut wl_compositor, data: *mut c_void) {
-    (WCH.wl_proxy_set_user_data)(compositor as *mut wl_proxy, data)
+    ffi_dispatch!(WCH, wl_proxy_set_user_data, compositor as *mut wl_proxy, data)
 }
 
 #[inline(always)]
 pub unsafe fn wl_compositor_get_user_data(compositor: *mut wl_compositor) -> *mut c_void {
-    (WCH.wl_proxy_get_user_data)(compositor as *mut wl_proxy)
+    ffi_dispatch!(WCH, wl_proxy_get_user_data, compositor as *mut wl_proxy)
 }
 
 #[inline(always)]
 pub unsafe fn wl_compositor_destroy(compositor: *mut wl_compositor) {
-    (WCH.wl_proxy_destroy)(compositor as *mut wl_proxy)
+    ffi_dispatch!(WCH, wl_proxy_destroy, compositor as *mut wl_proxy)
 }
 
 #[inline(always)]
 pub unsafe fn wl_compositor_create_surface(compositor: *mut wl_compositor) -> *mut wl_surface {
-    (WCH.wl_proxy_marshal_constructor)(
+    ffi_dispatch!(WCH, wl_proxy_marshal_constructor,
         compositor as *mut wl_proxy,
         WL_COMPOSITOR_CREATE_SURFACE,
-        WCH.wl_surface_interface,
+        ffi_dispatch_static!(WCH, wl_surface_interface),
         ptr::null_mut::<c_void>()
     ) as *mut wl_surface
 }
 
 #[inline(always)]
 pub unsafe fn wl_compositor_create_region(compositor: *mut wl_compositor) -> *mut wl_region {
-    (WCH.wl_proxy_marshal_constructor)(
+    ffi_dispatch!(WCH, wl_proxy_marshal_constructor,
         compositor as *mut wl_proxy,
         WL_COMPOSITOR_CREATE_REGION,
-        WCH.wl_region_interface,
+        ffi_dispatch_static!(WCH, wl_region_interface),
         ptr::null_mut::<c_void>()
     ) as *mut wl_region
 }

--- a/src/ffi/interfaces/data_device.rs
+++ b/src/ffi/interfaces/data_device.rs
@@ -1,6 +1,10 @@
 use libc::{c_int, c_void, uint32_t};
 
 use ffi::abi::{wl_proxy, wl_fixed_t};
+#[cfg(not(feature = "dlopen"))]
+use ffi::abi::{wl_proxy_destroy, wl_proxy_add_listener, wl_proxy_set_user_data,
+               wl_proxy_get_user_data, wl_proxy_marshal};
+#[cfg(feature = "dlopen")]
 use ffi::abi::WAYLAND_CLIENT_HANDLE as WCH;
 
 use super::data_offer::wl_data_offer;
@@ -50,7 +54,7 @@ pub unsafe fn wl_data_device_add_listener(data_device: *mut wl_data_device,
                                           listener: *const wl_data_device_listener,
                                           data: *mut c_void
                                          ) -> c_int {
-    (WCH.wl_proxy_add_listener)(
+    ffi_dispatch!(WCH, wl_proxy_add_listener,
         data_device as *mut wl_proxy,
         listener as *mut extern fn(),
         data
@@ -61,17 +65,17 @@ pub unsafe fn wl_data_device_add_listener(data_device: *mut wl_data_device,
 pub unsafe fn wl_data_device_set_user_data(data_device: *mut wl_data_device,
                                            data: *mut c_void
                                           ) {
-    (WCH.wl_proxy_set_user_data)(data_device as *mut wl_proxy, data)
+    ffi_dispatch!(WCH, wl_proxy_set_user_data, data_device as *mut wl_proxy, data)
 }
 
 #[inline(always)]
 pub unsafe fn wl_data_device_get_user_data(data_device: *mut wl_data_device) -> *mut c_void {
-    (WCH.wl_proxy_get_user_data)(data_device as *mut wl_proxy)
+    ffi_dispatch!(WCH, wl_proxy_get_user_data, data_device as *mut wl_proxy)
 }
 
 #[inline(always)]
 pub unsafe fn wl_data_device_destroy(data_device: *mut wl_data_device) {
-    (WCH.wl_proxy_destroy)(data_device as *mut wl_proxy)
+    ffi_dispatch!(WCH, wl_proxy_destroy, data_device as *mut wl_proxy)
 }
 
 #[inline(always)]
@@ -81,7 +85,7 @@ pub unsafe fn wl_data_device_start_drag(data_device: *mut wl_data_device,
                                         icon: *mut wl_surface,
                                         serial: uint32_t
                                        ) {
-    (WCH.wl_proxy_marshal)(
+    ffi_dispatch!(WCH, wl_proxy_marshal,
         data_device as *mut wl_proxy,
         WL_DATA_DEVICE_START_DRAG,
         source,
@@ -96,7 +100,7 @@ pub unsafe fn wl_data_device_set_selection(data_device: *mut wl_data_device,
                                            source: *mut wl_data_source,
                                            serial: uint32_t
                                           ) {
-    (WCH.wl_proxy_marshal)(
+    ffi_dispatch!(WCH, wl_proxy_marshal,
         data_device as *mut wl_proxy,
         WL_DATA_DEVICE_SET_SELECTION,
         source,
@@ -106,6 +110,6 @@ pub unsafe fn wl_data_device_set_selection(data_device: *mut wl_data_device,
 
 #[inline(always)]
 pub unsafe fn wl_data_device_release(data_device: *mut wl_data_device) {
-    (WCH.wl_proxy_marshal)(data_device as *mut wl_proxy, WL_DATA_DEVICE_RELEASE);
-    (WCH.wl_proxy_destroy)(data_device as *mut wl_proxy)
+    ffi_dispatch!(WCH, wl_proxy_marshal, data_device as *mut wl_proxy, WL_DATA_DEVICE_RELEASE);
+    ffi_dispatch!(WCH, wl_proxy_destroy, data_device as *mut wl_proxy)
 }

--- a/src/ffi/interfaces/data_device_manager.rs
+++ b/src/ffi/interfaces/data_device_manager.rs
@@ -3,6 +3,10 @@ use std::ptr;
 use libc::{c_void, uint32_t};
 
 use ffi::abi::wl_proxy;
+#[cfg(not(feature = "dlopen"))]
+use ffi::abi::{wl_proxy_destroy, wl_proxy_set_user_data, wl_proxy_get_user_data,
+               wl_proxy_marshal_constructor, wl_data_source_interface, wl_data_device_interface};
+#[cfg(feature = "dlopen")]
 use ffi::abi::WAYLAND_CLIENT_HANDLE as WCH;
 
 use super::data_device::wl_data_device;
@@ -18,27 +22,27 @@ const WL_DATA_DEVICE_MANAGER_GET_DATA_DEVICE: uint32_t = 1;
 pub unsafe fn wl_data_device_manager_set_user_data(ddm: *mut wl_data_device_manager,
                                                    data: *mut c_void
                                                   ) {
-    (WCH.wl_proxy_set_user_data)(ddm as *mut wl_proxy, data)
+    ffi_dispatch!(WCH, wl_proxy_set_user_data, ddm as *mut wl_proxy, data)
 }
 
 #[inline(always)]
 pub unsafe fn wl_data_device_manager_get_user_data(ddm: *mut wl_data_device_manager
                                                   ) -> *mut c_void {
-    (WCH.wl_proxy_get_user_data)(ddm as *mut wl_proxy)
+    ffi_dispatch!(WCH, wl_proxy_get_user_data, ddm as *mut wl_proxy)
 }
 
 #[inline(always)]
 pub unsafe fn wl_data_device_manager_destroy(ddm: *mut wl_data_device_manager) {
-    (WCH.wl_proxy_destroy)(ddm as *mut wl_proxy)
+    ffi_dispatch!(WCH, wl_proxy_destroy, ddm as *mut wl_proxy)
 }
 
 #[inline(always)]
 pub unsafe fn wl_data_device_manager_create_data_source(ddm: *mut wl_data_device_manager
                                                        ) -> *mut wl_data_source {
-    (WCH.wl_proxy_marshal_constructor)(
+    ffi_dispatch!(WCH, wl_proxy_marshal_constructor,
         ddm as *mut wl_proxy,
         WL_DATA_DEVICE_MANAGER_CREATE_DATA_SOURCE,
-        WCH.wl_data_source_interface,
+        ffi_dispatch_static!(WCH, wl_data_source_interface),
         ptr::null_mut::<c_void>()
     ) as *mut wl_data_source
 }
@@ -47,10 +51,10 @@ pub unsafe fn wl_data_device_manager_create_data_source(ddm: *mut wl_data_device
 pub unsafe fn wl_data_device_manager_get_data_device(ddm: *mut wl_data_device_manager,
                                                      seat: *mut wl_seat
                                                     ) -> *mut wl_data_device {
-    (WCH.wl_proxy_marshal_constructor)(
+    ffi_dispatch!(WCH, wl_proxy_marshal_constructor,
         ddm as *mut wl_proxy,
         WL_DATA_DEVICE_MANAGER_GET_DATA_DEVICE,
-        WCH.wl_data_device_interface,
+        ffi_dispatch_static!(WCH, wl_data_device_interface),
         ptr::null_mut::<c_void>(),
         seat
     ) as *mut wl_data_device

--- a/src/ffi/interfaces/data_offer.rs
+++ b/src/ffi/interfaces/data_offer.rs
@@ -1,6 +1,10 @@
 use libc::{c_int, c_void, c_char, uint32_t, int32_t};
 
 use ffi::abi::wl_proxy;
+#[cfg(not(feature = "dlopen"))]
+use ffi::abi::{wl_proxy_destroy, wl_proxy_add_listener, wl_proxy_set_user_data,
+               wl_proxy_get_user_data, wl_proxy_marshal};
+#[cfg(feature = "dlopen")]
 use ffi::abi::WAYLAND_CLIENT_HANDLE as WCH;
 
 #[repr(C)] pub struct wl_data_offer;
@@ -22,7 +26,7 @@ pub unsafe fn wl_data_offer_add_listener(data_offer: *mut wl_data_offer,
                                          listener: *const wl_data_offer_listener,
                                          data: *mut c_void
                                         ) -> c_int {
-    (WCH.wl_proxy_add_listener)(
+    ffi_dispatch!(WCH, wl_proxy_add_listener,
         data_offer as *mut wl_proxy,
         listener as *mut extern fn(),
         data
@@ -31,12 +35,12 @@ pub unsafe fn wl_data_offer_add_listener(data_offer: *mut wl_data_offer,
 
 #[inline(always)]
 pub unsafe fn wl_data_offer_set_user_data(data_offer: *mut wl_data_offer, data: *mut c_void) {
-    (WCH.wl_proxy_set_user_data)(data_offer as *mut wl_proxy, data)
+    ffi_dispatch!(WCH, wl_proxy_set_user_data,data_offer as *mut wl_proxy, data)
 }
 
 #[inline(always)]
 pub unsafe fn wl_data_offer_get_user_data(data_offer: *mut wl_data_offer) -> *mut c_void {
-    (WCH.wl_proxy_get_user_data)(data_offer as *mut wl_proxy)
+    ffi_dispatch!(WCH, wl_proxy_get_user_data,data_offer as *mut wl_proxy)
 }
 
 #[inline(always)]
@@ -44,7 +48,7 @@ pub unsafe fn wl_data_offer_accept(data_offer: *mut wl_data_offer,
                                    serial: uint32_t,
                                    mime_type: *const c_char
                                   ) {
-    (WCH.wl_proxy_marshal)(
+    ffi_dispatch!(WCH, wl_proxy_marshal,
         data_offer as *mut wl_proxy,
         WL_DATA_OFFER_ACCEPT,
         serial,
@@ -57,7 +61,7 @@ pub unsafe fn wl_data_offer_receive(data_offer: *mut wl_data_offer,
                                     mime_type: *const c_char,
                                     fd: int32_t
                                    ) {
-    (WCH.wl_proxy_marshal)(
+    ffi_dispatch!(WCH, wl_proxy_marshal,
         data_offer as *mut wl_proxy,
         WL_DATA_OFFER_RECEIVE,
         mime_type,
@@ -67,6 +71,6 @@ pub unsafe fn wl_data_offer_receive(data_offer: *mut wl_data_offer,
 
 #[inline(always)]
 pub unsafe fn wl_data_offer_destroy(data_offer: *mut wl_data_offer) {
-    (WCH.wl_proxy_marshal)(data_offer as *mut wl_proxy, WL_DATA_OFFER_DESTROY);
-    (WCH.wl_proxy_destroy)(data_offer as *mut wl_proxy)
+    ffi_dispatch!(WCH, wl_proxy_marshal,data_offer as *mut wl_proxy, WL_DATA_OFFER_DESTROY);
+    ffi_dispatch!(WCH, wl_proxy_destroy,data_offer as *mut wl_proxy)
 }

--- a/src/ffi/interfaces/data_source.rs
+++ b/src/ffi/interfaces/data_source.rs
@@ -1,6 +1,10 @@
 use libc::{c_int, c_void, c_char, uint32_t, int32_t};
 
 use ffi::abi::wl_proxy;
+#[cfg(not(feature = "dlopen"))]
+use ffi::abi::{wl_proxy_destroy, wl_proxy_add_listener, wl_proxy_set_user_data,
+               wl_proxy_get_user_data, wl_proxy_marshal};
+#[cfg(feature = "dlopen")]
 use ffi::abi::WAYLAND_CLIENT_HANDLE as WCH;
 
 #[repr(C)] pub struct wl_data_source;
@@ -29,7 +33,7 @@ pub unsafe fn wl_data_source_add_listener(data_source: *mut wl_data_source,
                                           listener: *const wl_data_source_listener,
                                           data: *mut c_void
                                          ) -> c_int {
-    (WCH.wl_proxy_add_listener)(
+    ffi_dispatch!(WCH, wl_proxy_add_listener,
         data_source as *mut wl_proxy,
         listener as *mut extern fn(),
         data
@@ -38,17 +42,17 @@ pub unsafe fn wl_data_source_add_listener(data_source: *mut wl_data_source,
 
 #[inline(always)]
 pub unsafe fn wl_data_source_set_user_data(data_source: *mut wl_data_source, data: *mut c_void) {
-    (WCH.wl_proxy_set_user_data)(data_source as *mut wl_proxy, data)
+    ffi_dispatch!(WCH, wl_proxy_set_user_data,data_source as *mut wl_proxy, data)
 }
 
 #[inline(always)]
 pub unsafe fn wl_data_source_get_user_data(data_source: *mut wl_data_source) -> *mut c_void {
-    (WCH.wl_proxy_get_user_data)(data_source as *mut wl_proxy)
+    ffi_dispatch!(WCH, wl_proxy_get_user_data,data_source as *mut wl_proxy)
 }
 
 #[inline(always)]
 pub unsafe fn wl_data_source_offer(data_source: *mut wl_data_source, mime_type: *const c_char) {
-    (WCH.wl_proxy_marshal)(
+    ffi_dispatch!(WCH, wl_proxy_marshal,
         data_source as *mut wl_proxy,
         WL_DATA_SOURCE_OFFER,
         mime_type
@@ -57,6 +61,6 @@ pub unsafe fn wl_data_source_offer(data_source: *mut wl_data_source, mime_type: 
 
 #[inline(always)]
 pub unsafe fn wl_data_source_destroy(data_source: *mut wl_data_source) {
-    (WCH.wl_proxy_marshal)(data_source as *mut wl_proxy, WL_DATA_SOURCE_DESTROY);
-    (WCH.wl_proxy_destroy)(data_source as *mut wl_proxy)
+    ffi_dispatch!(WCH, wl_proxy_marshal,data_source as *mut wl_proxy, WL_DATA_SOURCE_DESTROY);
+    ffi_dispatch!(WCH, wl_proxy_destroy,data_source as *mut wl_proxy)
 }

--- a/src/ffi/interfaces/display.rs
+++ b/src/ffi/interfaces/display.rs
@@ -3,6 +3,10 @@ use std::ptr;
 use libc::{c_int, c_void,c_char, uint32_t};
 
 use ffi::abi::wl_proxy;
+#[cfg(not(feature = "dlopen"))]
+use ffi::abi::{wl_proxy_add_listener, wl_proxy_set_user_data, wl_proxy_get_user_data,
+               wl_proxy_marshal_constructor, wl_callback_interface, wl_registry_interface};
+#[cfg(feature = "dlopen")]
 use ffi::abi::WAYLAND_CLIENT_HANDLE as WCH;
 
 pub use ffi::abi::wl_display;
@@ -32,7 +36,7 @@ pub unsafe fn wl_display_add_listener(display: *mut wl_display,
                                       listener: *const wl_display_listener,
                                       data: *mut c_void
                                      ) -> c_int {
-    (WCH.wl_proxy_add_listener)(
+    ffi_dispatch!(WCH, wl_proxy_add_listener,
         display as *mut wl_proxy,
         listener as *mut extern fn(),
         data
@@ -41,30 +45,30 @@ pub unsafe fn wl_display_add_listener(display: *mut wl_display,
 
 #[inline(always)]
 pub unsafe fn wl_display_set_user_data(display: *mut wl_display, data: *mut c_void) {
-    (WCH.wl_proxy_set_user_data)(display as *mut wl_proxy, data)
+    ffi_dispatch!(WCH, wl_proxy_set_user_data,display as *mut wl_proxy, data)
 }
 
 #[inline(always)]
 pub unsafe fn wl_display_get_user_data(display: *mut wl_display) -> *mut c_void {
-    (WCH.wl_proxy_get_user_data)(display as *mut wl_proxy)
+    ffi_dispatch!(WCH, wl_proxy_get_user_data,display as *mut wl_proxy)
 }
 
 #[inline(always)]
 pub unsafe fn wl_display_sync(display: *mut wl_display) -> *mut wl_callback {
-    (WCH.wl_proxy_marshal_constructor)(
+    ffi_dispatch!(WCH, wl_proxy_marshal_constructor,
         display as *mut wl_proxy,
         WL_DISPLAY_SYNC,
-        WCH.wl_callback_interface,
+        ffi_dispatch_static!(WCH, wl_callback_interface),
         ptr::null_mut::<c_void>()
     ) as *mut wl_callback
 }
 
 #[inline(always)]
 pub unsafe fn wl_display_get_registry(display: *mut wl_display) -> *mut wl_registry {
-    (WCH.wl_proxy_marshal_constructor)(
+    ffi_dispatch!(WCH, wl_proxy_marshal_constructor,
         display as *mut wl_proxy,
         WL_DISPLAY_GET_REGISTRY,
-        WCH.wl_registry_interface,
+        ffi_dispatch_static!(WCH, wl_registry_interface),
         ptr::null_mut::<c_void>()
     ) as *mut wl_registry
 }

--- a/src/ffi/interfaces/keyboard.rs
+++ b/src/ffi/interfaces/keyboard.rs
@@ -1,6 +1,10 @@
 use libc::{c_int, c_void, uint32_t, int32_t};
 
 use ffi::abi::{wl_proxy, wl_array};
+#[cfg(not(feature = "dlopen"))]
+use ffi::abi::{wl_proxy_destroy, wl_proxy_add_listener, wl_proxy_set_user_data,
+               wl_proxy_get_user_data, wl_proxy_marshal};
+#[cfg(feature = "dlopen")]
 use ffi::abi::WAYLAND_CLIENT_HANDLE as WCH;
 
 use ffi::enums::{wl_keyboard_keymap_format, wl_keyboard_key_state};
@@ -57,7 +61,7 @@ pub unsafe fn wl_keyboard_add_listener(keyboard: *mut wl_keyboard,
                                        listener: *const wl_keyboard_listener,
                                        data: *mut c_void
                                       ) -> c_int {
-    (WCH.wl_proxy_add_listener)(
+    ffi_dispatch!(WCH, wl_proxy_add_listener,
         keyboard as *mut wl_proxy,
         listener as *mut extern fn(),
         data
@@ -66,21 +70,21 @@ pub unsafe fn wl_keyboard_add_listener(keyboard: *mut wl_keyboard,
 
 #[inline(always)]
 pub unsafe fn wl_keyboard_set_user_data(keyboard: *mut wl_keyboard, data: *mut c_void) {
-    (WCH.wl_proxy_set_user_data)(keyboard as *mut wl_proxy, data)
+    ffi_dispatch!(WCH, wl_proxy_set_user_data,keyboard as *mut wl_proxy, data)
 }
 
 #[inline(always)]
 pub unsafe fn wl_keyboard_get_user_data(keyboard: *mut wl_keyboard) -> *mut c_void {
-    (WCH.wl_proxy_get_user_data)(keyboard as *mut wl_proxy)
+    ffi_dispatch!(WCH, wl_proxy_get_user_data,keyboard as *mut wl_proxy)
 }
 
 #[inline(always)]
 pub unsafe fn wl_keyboard_destroy(keyboard: *mut wl_keyboard) {
-    (WCH.wl_proxy_destroy)(keyboard as *mut wl_proxy)
+    ffi_dispatch!(WCH, wl_proxy_destroy,keyboard as *mut wl_proxy)
 }
 
 #[inline(always)]
 pub unsafe fn wl_keyboard_release(keyboard: *mut wl_keyboard) {
-    (WCH.wl_proxy_marshal)(keyboard as *mut wl_proxy, WL_KEYBOARD_RELEASE);
-    (WCH.wl_proxy_destroy)(keyboard as *mut wl_proxy)
+    ffi_dispatch!(WCH, wl_proxy_marshal,keyboard as *mut wl_proxy, WL_KEYBOARD_RELEASE);
+    ffi_dispatch!(WCH, wl_proxy_destroy,keyboard as *mut wl_proxy)
 }

--- a/src/ffi/interfaces/output.rs
+++ b/src/ffi/interfaces/output.rs
@@ -1,6 +1,10 @@
 use libc::{c_int, c_void, c_char, int32_t};
 
 use ffi::abi::wl_proxy;
+#[cfg(not(feature = "dlopen"))]
+use ffi::abi::{wl_proxy_destroy, wl_proxy_add_listener, wl_proxy_set_user_data,
+               wl_proxy_get_user_data};
+#[cfg(feature = "dlopen")]
 use ffi::abi::WAYLAND_CLIENT_HANDLE as WCH;
 use ffi::enums::{wl_output_mode, wl_output_subpixel, wl_output_transform};
 
@@ -38,7 +42,7 @@ pub unsafe fn wl_output_add_listener(output: *mut wl_output,
                                      listener: *const wl_output_listener,
                                      data: *mut c_void
                                     ) -> c_int {
-    (WCH.wl_proxy_add_listener)(
+    ffi_dispatch!(WCH, wl_proxy_add_listener,
         output as *mut wl_proxy,
         listener as *mut extern fn(),
         data
@@ -47,15 +51,15 @@ pub unsafe fn wl_output_add_listener(output: *mut wl_output,
 
 #[inline(always)]
 pub unsafe fn wl_output_set_user_data(output: *mut wl_output, data: *mut c_void) {
-    (WCH.wl_proxy_set_user_data)(output as *mut wl_proxy, data)
+    ffi_dispatch!(WCH, wl_proxy_set_user_data,output as *mut wl_proxy, data)
 }
 
 #[inline(always)]
 pub unsafe fn wl_output_get_user_data(output: *mut wl_output) -> *mut c_void {
-    (WCH.wl_proxy_get_user_data)(output as *mut wl_proxy)
+    ffi_dispatch!(WCH, wl_proxy_get_user_data,output as *mut wl_proxy)
 }
 
 #[inline(always)]
 pub unsafe fn wl_output_destroy(output: *mut wl_output) {
-    (WCH.wl_proxy_destroy)(output as *mut wl_proxy)
+    ffi_dispatch!(WCH, wl_proxy_destroy,output as *mut wl_proxy)
 }

--- a/src/ffi/interfaces/pointer.rs
+++ b/src/ffi/interfaces/pointer.rs
@@ -1,6 +1,10 @@
 use libc::{c_int, c_void, uint32_t, int32_t};
 
 use ffi::abi::{wl_proxy, wl_fixed_t};
+#[cfg(not(feature = "dlopen"))]
+use ffi::abi::{wl_proxy_destroy, wl_proxy_add_listener, wl_proxy_set_user_data,
+               wl_proxy_get_user_data, wl_proxy_marshal};
+#[cfg(feature = "dlopen")]
 use ffi::abi::WAYLAND_CLIENT_HANDLE as WCH;
 use ffi::enums::{wl_pointer_button_state, wl_pointer_axis};
 
@@ -51,7 +55,7 @@ pub unsafe fn wl_pointer_add_listener(pointer: *mut wl_pointer,
                                       listener: *const wl_pointer_listener,
                                       data: *mut c_void
                                      ) -> c_int {
-    (WCH.wl_proxy_add_listener)(
+    ffi_dispatch!(WCH, wl_proxy_add_listener,
         pointer as *mut wl_proxy,
         listener as *mut extern fn(),
         data
@@ -60,17 +64,17 @@ pub unsafe fn wl_pointer_add_listener(pointer: *mut wl_pointer,
 
 #[inline(always)]
 pub unsafe fn wl_pointer_set_user_data(pointer: *mut wl_pointer, data: *mut c_void) {
-    (WCH.wl_proxy_set_user_data)(pointer as *mut wl_proxy, data)
+    ffi_dispatch!(WCH, wl_proxy_set_user_data,pointer as *mut wl_proxy, data)
 }
 
 #[inline(always)]
 pub unsafe fn wl_pointer_get_user_data(pointer: *mut wl_pointer) -> *mut c_void {
-    (WCH.wl_proxy_get_user_data)(pointer as *mut wl_proxy)
+    ffi_dispatch!(WCH, wl_proxy_get_user_data,pointer as *mut wl_proxy)
 }
 
 #[inline(always)]
 pub unsafe fn wl_pointer_destroy(pointer: *mut wl_pointer) {
-    (WCH.wl_proxy_destroy)(pointer as *mut wl_proxy)
+    ffi_dispatch!(WCH, wl_proxy_destroy,pointer as *mut wl_proxy)
 }
 
 #[inline(always)]
@@ -80,7 +84,7 @@ pub unsafe fn wl_pointer_set_cursor(pointer: *mut wl_pointer,
                                     hotspot_x: int32_t,
                                     hotspot_y: int32_t
                                    ) {
-    (WCH.wl_proxy_marshal)(
+    ffi_dispatch!(WCH, wl_proxy_marshal,
         pointer as *mut wl_proxy,
         WL_POINTER_SET_CURSOR,
         serial,
@@ -92,6 +96,6 @@ pub unsafe fn wl_pointer_set_cursor(pointer: *mut wl_pointer,
 
 #[inline(always)]
 pub unsafe fn wl_pointer_release(pointer: *mut wl_pointer) {
-    (WCH.wl_proxy_marshal)(pointer as *mut wl_proxy, WL_POINTER_RELEASE);
-    (WCH.wl_proxy_destroy)(pointer as *mut wl_proxy)
+    ffi_dispatch!(WCH, wl_proxy_marshal,pointer as *mut wl_proxy, WL_POINTER_RELEASE);
+    ffi_dispatch!(WCH, wl_proxy_destroy,pointer as *mut wl_proxy)
 }

--- a/src/ffi/interfaces/region.rs
+++ b/src/ffi/interfaces/region.rs
@@ -1,6 +1,10 @@
 use libc::{c_void, uint32_t, int32_t};
 
 use ffi::abi::wl_proxy;
+#[cfg(not(feature = "dlopen"))]
+use ffi::abi::{wl_proxy_destroy, wl_proxy_set_user_data,
+               wl_proxy_get_user_data, wl_proxy_marshal};
+#[cfg(feature = "dlopen")]
 use ffi::abi::WAYLAND_CLIENT_HANDLE as WCH;
 
 #[repr(C)] pub struct wl_region;
@@ -11,18 +15,18 @@ const WL_REGION_SUBTRACT: uint32_t = 2;
 
 #[inline(always)]
 pub unsafe fn wl_region_set_user_data(region: *mut wl_region, data: *mut c_void) {
-    (WCH.wl_proxy_set_user_data)(region as *mut wl_proxy, data)
+    ffi_dispatch!(WCH, wl_proxy_set_user_data,region as *mut wl_proxy, data)
 }
 
 #[inline(always)]
 pub unsafe fn wl_region_get_user_data(region: *mut wl_region) -> *mut c_void {
-    (WCH.wl_proxy_get_user_data)(region as *mut wl_proxy)
+    ffi_dispatch!(WCH, wl_proxy_get_user_data,region as *mut wl_proxy)
 }
 
 #[inline(always)]
 pub unsafe fn wl_region_destroy(region: *mut wl_region) {
-    (WCH.wl_proxy_marshal)(region as *mut wl_proxy, WL_REGION_DESTROY);
-    (WCH.wl_proxy_destroy)(region as *mut wl_proxy)
+    ffi_dispatch!(WCH, wl_proxy_marshal,region as *mut wl_proxy, WL_REGION_DESTROY);
+    ffi_dispatch!(WCH, wl_proxy_destroy,region as *mut wl_proxy)
 }
 
 #[inline(always)]
@@ -32,7 +36,7 @@ pub unsafe fn wl_region_add(region: *mut wl_region,
                             width: int32_t,
                             height: int32_t
                            ) {
-    (WCH.wl_proxy_marshal)(region as *mut wl_proxy, WL_REGION_ADD, x, y, width, height)
+    ffi_dispatch!(WCH, wl_proxy_marshal,region as *mut wl_proxy, WL_REGION_ADD, x, y, width, height)
 }
 
 #[inline(always)]
@@ -42,5 +46,5 @@ pub unsafe fn wl_region_subtract(region: *mut wl_region,
                                  width: int32_t,
                                  height: int32_t
                                 ) {
-    (WCH.wl_proxy_marshal)(region as *mut wl_proxy, WL_REGION_SUBTRACT, x, y, width, height)
+    ffi_dispatch!(WCH, wl_proxy_marshal,region as *mut wl_proxy, WL_REGION_SUBTRACT, x, y, width, height)
 }

--- a/src/ffi/interfaces/registry.rs
+++ b/src/ffi/interfaces/registry.rs
@@ -3,6 +3,10 @@ use std::ptr;
 use libc::{c_int, c_void, c_char, uint32_t};
 
 use ffi::abi::{wl_proxy, wl_interface};
+#[cfg(not(feature = "dlopen"))]
+use ffi::abi::{wl_proxy_destroy, wl_proxy_add_listener, wl_proxy_set_user_data,
+               wl_proxy_get_user_data, wl_proxy_marshal_constructor};
+#[cfg(feature = "dlopen")]
 use ffi::abi::WAYLAND_CLIENT_HANDLE as WCH;
 
 #[repr(C)] pub struct wl_registry;
@@ -28,7 +32,7 @@ pub unsafe fn wl_registry_add_listener(registry: *mut wl_registry,
                                        listener: *const wl_registry_listener,
                                        data: *mut c_void
                                       ) -> c_int {
-    (WCH.wl_proxy_add_listener)(
+    ffi_dispatch!(WCH, wl_proxy_add_listener,
         registry as *mut wl_proxy,
         listener as *mut extern fn(),
         data
@@ -37,17 +41,17 @@ pub unsafe fn wl_registry_add_listener(registry: *mut wl_registry,
 
 #[inline(always)]
 pub unsafe fn wl_registry_set_user_data(registry: *mut wl_registry, data: *mut c_void) {
-    (WCH.wl_proxy_set_user_data)(registry as *mut wl_proxy, data)
+    ffi_dispatch!(WCH, wl_proxy_set_user_data,registry as *mut wl_proxy, data)
 }
 
 #[inline(always)]
 pub unsafe fn wl_registry_get_user_data(registry: *mut wl_registry) -> *mut c_void {
-    (WCH.wl_proxy_get_user_data)(registry as *mut wl_proxy)
+    ffi_dispatch!(WCH, wl_proxy_get_user_data,registry as *mut wl_proxy)
 }
 
 #[inline(always)]
 pub unsafe fn wl_registry_destroy(registry: *mut wl_registry) {
-    (WCH.wl_proxy_destroy)(registry as *mut wl_proxy)
+    ffi_dispatch!(WCH, wl_proxy_destroy,registry as *mut wl_proxy)
 }
 
 #[inline(always)]
@@ -56,7 +60,7 @@ pub unsafe fn wl_registry_bind(registry: *mut wl_registry,
                                interface: *const wl_interface,
                                version: uint32_t
                               ) -> *mut c_void {
-    let id = (WCH.wl_proxy_marshal_constructor)(
+    let id = ffi_dispatch!(WCH, wl_proxy_marshal_constructor,
         registry as *mut wl_proxy,
         WL_REGISTRY_BIND,
         interface,

--- a/src/ffi/interfaces/seat.rs
+++ b/src/ffi/interfaces/seat.rs
@@ -3,6 +3,11 @@ use std::ptr;
 use libc::{c_int, c_void, c_char, uint32_t};
 
 use ffi::abi::wl_proxy;
+#[cfg(not(feature = "dlopen"))]
+use ffi::abi::{wl_proxy_destroy, wl_proxy_add_listener, wl_proxy_set_user_data,
+               wl_proxy_get_user_data, wl_proxy_marshal_constructor,
+               wl_pointer_interface, wl_keyboard_interface, wl_touch_interface};
+#[cfg(feature = "dlopen")]
 use ffi::abi::WAYLAND_CLIENT_HANDLE as WCH;
 use ffi::enums::wl_seat_capability;
 
@@ -33,7 +38,7 @@ pub unsafe fn wl_seat_add_listener(seat: *mut wl_seat,
                                    listener: *const wl_seat_listener,
                                    data: *mut c_void
                                   ) -> c_int {
-    (WCH.wl_proxy_add_listener)(
+    ffi_dispatch!(WCH, wl_proxy_add_listener,
         seat as *mut wl_proxy,
         listener as *mut extern fn(),
         data
@@ -42,45 +47,45 @@ pub unsafe fn wl_seat_add_listener(seat: *mut wl_seat,
 
 #[inline(always)]
 pub unsafe fn wl_seat_set_user_data(seat: *mut wl_seat, data: *mut c_void) {
-    (WCH.wl_proxy_set_user_data)(seat as *mut wl_proxy, data)
+    ffi_dispatch!(WCH, wl_proxy_set_user_data,seat as *mut wl_proxy, data)
 }
 
 #[inline(always)]
 pub unsafe fn wl_seat_get_user_data(seat: *mut wl_seat) -> *mut c_void {
-    (WCH.wl_proxy_get_user_data)(seat as *mut wl_proxy)
+    ffi_dispatch!(WCH, wl_proxy_get_user_data,seat as *mut wl_proxy)
 }
 
 #[inline(always)]
 pub unsafe fn wl_seat_destroy(seat: *mut wl_seat) {
-    (WCH.wl_proxy_destroy)(seat as *mut wl_proxy)
+    ffi_dispatch!(WCH, wl_proxy_destroy,seat as *mut wl_proxy)
 }
 
 #[inline(always)]
 pub unsafe fn wl_seat_get_pointer(seat: *mut wl_seat) -> *mut wl_pointer {
-    (WCH.wl_proxy_marshal_constructor)(
+    ffi_dispatch!(WCH, wl_proxy_marshal_constructor,
         seat as *mut wl_proxy,
         WL_SEAT_GET_POINTER,
-        WCH.wl_pointer_interface,
+        ffi_dispatch_static!(WCH, wl_pointer_interface),
         ptr::null_mut::<c_void>()
     ) as *mut wl_pointer
 }
 
 #[inline(always)]
 pub unsafe fn wl_seat_get_keyboard(seat: *mut wl_seat) -> *mut wl_keyboard {
-    (WCH.wl_proxy_marshal_constructor)(
+    ffi_dispatch!(WCH, wl_proxy_marshal_constructor,
         seat as *mut wl_proxy,
         WL_SEAT_GET_KEYBOARD,
-        WCH.wl_keyboard_interface,
+        ffi_dispatch_static!(WCH, wl_keyboard_interface),
         ptr::null_mut::<c_void>()
     ) as *mut wl_keyboard
 }
 
 #[inline(always)]
 pub unsafe fn wl_seat_get_touch(seat: *mut wl_seat) -> *mut wl_touch {
-    (WCH.wl_proxy_marshal_constructor)(
+    ffi_dispatch!(WCH, wl_proxy_marshal_constructor,
         seat as *mut wl_proxy,
         WL_SEAT_GET_TOUCH,
-        WCH.wl_touch_interface,
+        ffi_dispatch_static!(WCH, wl_touch_interface),
         ptr::null_mut::<c_void>()
     ) as *mut wl_touch
 }

--- a/src/ffi/interfaces/shell.rs
+++ b/src/ffi/interfaces/shell.rs
@@ -3,6 +3,10 @@ use std::ptr;
 use libc::{c_void, uint32_t};
 
 use ffi::abi::wl_proxy;
+#[cfg(not(feature = "dlopen"))]
+use ffi::abi::{wl_proxy_destroy, wl_proxy_set_user_data, wl_proxy_get_user_data,
+               wl_proxy_marshal_constructor, wl_shell_surface_interface};
+#[cfg(feature = "dlopen")]
 use ffi::abi::WAYLAND_CLIENT_HANDLE as WCH;
 
 use super::shell_surface::wl_shell_surface;
@@ -14,27 +18,27 @@ const WL_SHELL_GET_SHELL_SURFACE: uint32_t = 0;
 
 #[inline(always)]
 pub unsafe fn wl_shell_set_user_data(shell: *mut wl_shell, data: *mut c_void) {
-    (WCH.wl_proxy_set_user_data)(shell as *mut wl_proxy, data)
+    ffi_dispatch!(WCH, wl_proxy_set_user_data,shell as *mut wl_proxy, data)
 }
 
 #[inline(always)]
 pub unsafe fn wl_shell_get_user_data(shell: *mut wl_shell) -> *mut c_void {
-    (WCH.wl_proxy_get_user_data)(shell as *mut wl_proxy)
+    ffi_dispatch!(WCH, wl_proxy_get_user_data,shell as *mut wl_proxy)
 }
 
 #[inline(always)]
 pub unsafe fn wl_shell_destroy(shell: *mut wl_shell) {
-    (WCH.wl_proxy_destroy)(shell as *mut wl_proxy)
+    ffi_dispatch!(WCH, wl_proxy_destroy,shell as *mut wl_proxy)
 }
 
 #[inline(always)]
 pub unsafe fn wl_shell_get_shell_surface(shell: *mut wl_shell,
                                          surface: *mut wl_surface
                                         ) -> *mut wl_shell_surface {
-    (WCH.wl_proxy_marshal_constructor)(
+    ffi_dispatch!(WCH, wl_proxy_marshal_constructor,
         shell as *mut wl_proxy,
         WL_SHELL_GET_SHELL_SURFACE,
-        WCH.wl_shell_surface_interface,
+        ffi_dispatch_static!(WCH, wl_shell_surface_interface),
         ptr::null_mut::<c_void>(),
         surface
     ) as *mut wl_shell_surface

--- a/src/ffi/interfaces/shell_surface.rs
+++ b/src/ffi/interfaces/shell_surface.rs
@@ -1,6 +1,10 @@
 use libc::{c_int, c_void, c_char, uint32_t, int32_t};
 
 use ffi::abi::wl_proxy;
+#[cfg(not(feature = "dlopen"))]
+use ffi::abi::{wl_proxy_destroy, wl_proxy_add_listener, wl_proxy_set_user_data,
+               wl_proxy_get_user_data, wl_proxy_marshal};
+#[cfg(feature = "dlopen")]
 use ffi::abi::WAYLAND_CLIENT_HANDLE as WCH;
 use ffi::enums::wl_shell_surface_fullscreen_method;
 use ffi::enums::wl_shell_surface_resize as wl_shell_surface_resize_e;
@@ -44,7 +48,7 @@ pub unsafe fn wl_shell_surface_add_listener(shell_surface: *mut wl_shell_surface
                                             listener: *const wl_shell_surface_listener,
                                             data: *mut c_void
                                            ) -> c_int {
-    (WCH.wl_proxy_add_listener)(
+    ffi_dispatch!(WCH, wl_proxy_add_listener,
         shell_surface as *mut wl_proxy,
         listener as *mut extern fn(),
         data
@@ -55,22 +59,22 @@ pub unsafe fn wl_shell_surface_add_listener(shell_surface: *mut wl_shell_surface
 pub unsafe fn wl_shell_surface_set_user_data(shell_surface: *mut wl_shell_surface,
                                              data: *mut c_void
                                             ) {
-    (WCH.wl_proxy_set_user_data)(shell_surface as *mut wl_proxy, data)
+    ffi_dispatch!(WCH, wl_proxy_set_user_data,shell_surface as *mut wl_proxy, data)
 }
 
 #[inline(always)]
 pub unsafe fn wl_shell_surface_get_user_data(shell_surface: *mut wl_shell_surface) -> *mut c_void {
-    (WCH.wl_proxy_get_user_data)(shell_surface as *mut wl_proxy)
+    ffi_dispatch!(WCH, wl_proxy_get_user_data,shell_surface as *mut wl_proxy)
 }
 
 #[inline(always)]
 pub unsafe fn wl_shell_surface_destroy(shell_surface: *mut wl_shell_surface) {
-    (WCH.wl_proxy_destroy)(shell_surface as *mut wl_proxy)
+    ffi_dispatch!(WCH, wl_proxy_destroy,shell_surface as *mut wl_proxy)
 }
 
 #[inline(always)]
 pub unsafe fn wl_shell_surface_pong(shell_surface: *mut wl_shell_surface, serial: uint32_t) {
-    (WCH.wl_proxy_marshal)(shell_surface as *mut wl_proxy, WL_SHELL_SURFACE_PONG, serial)
+    ffi_dispatch!(WCH, wl_proxy_marshal,shell_surface as *mut wl_proxy, WL_SHELL_SURFACE_PONG, serial)
 }
 
 #[inline(always)]
@@ -78,7 +82,7 @@ pub unsafe fn wl_shell_surface_move(shell_surface: *mut wl_shell_surface,
                                     seat: *mut wl_seat,
                                     serial: uint32_t
                                    ) {
-    (WCH.wl_proxy_marshal)(
+    ffi_dispatch!(WCH, wl_proxy_marshal,
         shell_surface as *mut wl_proxy,
         WL_SHELL_SURFACE_MOVE,
         seat,
@@ -92,7 +96,7 @@ pub unsafe fn wl_shell_surface_resize(shell_surface: *mut wl_shell_surface,
                                       serial: uint32_t,
                                       edges: uint32_t
                                      ) {
-    (WCH.wl_proxy_marshal)(
+    ffi_dispatch!(WCH, wl_proxy_marshal,
         shell_surface as *mut wl_proxy,
         WL_SHELL_SURFACE_RESIZE,
         seat,
@@ -103,7 +107,7 @@ pub unsafe fn wl_shell_surface_resize(shell_surface: *mut wl_shell_surface,
 
 #[inline(always)]
 pub unsafe fn wl_shell_surface_set_toplevel(shell_surface: *mut wl_shell_surface) {
-    (WCH.wl_proxy_marshal)(shell_surface as *mut wl_proxy, WL_SHELL_SURFACE_SET_TOPLEVEL)
+    ffi_dispatch!(WCH, wl_proxy_marshal,shell_surface as *mut wl_proxy, WL_SHELL_SURFACE_SET_TOPLEVEL)
 }
 
 #[inline(always)]
@@ -113,7 +117,7 @@ pub unsafe fn wl_shell_surface_set_transient(shell_surface: *mut wl_shell_surfac
                                              y: int32_t,
                                              flags: uint32_t
                                             ) {
-    (WCH.wl_proxy_marshal)(
+    ffi_dispatch!(WCH, wl_proxy_marshal,
         shell_surface as *mut wl_proxy,
         WL_SHELL_SURFACE_SET_TRANSIENT,
         parent,
@@ -129,7 +133,7 @@ pub unsafe fn wl_shell_surface_set_fullscreen(shell_surface: *mut wl_shell_surfa
                                               framerate: uint32_t,
                                               output: *mut wl_output
                                              ) {
-    (WCH.wl_proxy_marshal)(
+    ffi_dispatch!(WCH, wl_proxy_marshal,
         shell_surface as *mut wl_proxy,
         WL_SHELL_SURFACE_SET_FULLSCREEN,
         method,
@@ -147,7 +151,7 @@ pub unsafe fn wl_shell_surface_set_popup(shell_surface: *mut wl_shell_surface,
                                          y: int32_t,
                                          flags: uint32_t
                                         ) {
-    (WCH.wl_proxy_marshal)(
+    ffi_dispatch!(WCH, wl_proxy_marshal,
         shell_surface as *mut wl_proxy,
         WL_SHELL_SURFACE_SET_POPUP,
         seat,
@@ -163,7 +167,7 @@ pub unsafe fn wl_shell_surface_set_popup(shell_surface: *mut wl_shell_surface,
 pub unsafe fn wl_shell_surface_set_maximized(shell_surface: *mut wl_shell_surface,
                                              output: *mut wl_output
                                             ) {
-    (WCH.wl_proxy_marshal)(
+    ffi_dispatch!(WCH, wl_proxy_marshal,
         shell_surface as *mut wl_proxy,
         WL_SHELL_SURFACE_SET_MAXIMIZED,
         output
@@ -174,7 +178,7 @@ pub unsafe fn wl_shell_surface_set_maximized(shell_surface: *mut wl_shell_surfac
 pub unsafe fn wl_shell_surface_set_title(shell_surface: *mut wl_shell_surface,
                                          title: *const c_char
                                         ) {
-    (WCH.wl_proxy_marshal)(
+    ffi_dispatch!(WCH, wl_proxy_marshal,
         shell_surface as *mut wl_proxy,
         WL_SHELL_SURFACE_SET_TITLE,
         title
@@ -185,7 +189,7 @@ pub unsafe fn wl_shell_surface_set_title(shell_surface: *mut wl_shell_surface,
 pub unsafe fn wl_shell_surface_set_class(shell_surface: *mut wl_shell_surface,
                                          class_: *const c_char
                                         ) {
-    (WCH.wl_proxy_marshal)(
+    ffi_dispatch!(WCH, wl_proxy_marshal,
         shell_surface as *mut wl_proxy,
         WL_SHELL_SURFACE_SET_CLASS,
         class_

--- a/src/ffi/interfaces/shm.rs
+++ b/src/ffi/interfaces/shm.rs
@@ -3,6 +3,11 @@ use std::ptr;
 use libc::{c_int, c_void, uint32_t, int32_t};
 
 use ffi::abi::wl_proxy;
+#[cfg(not(feature = "dlopen"))]
+use ffi::abi::{wl_proxy_destroy, wl_proxy_add_listener, wl_proxy_set_user_data,
+               wl_proxy_get_user_data, wl_proxy_marshal_constructor,
+               wl_shm_pool_interface};
+#[cfg(feature = "dlopen")]
 use ffi::abi::WAYLAND_CLIENT_HANDLE as WCH;
 
 use super::shm_pool::wl_shm_pool;
@@ -24,7 +29,7 @@ pub unsafe fn wl_shm_add_listener(shm: *mut wl_shm,
                                   listener: *const wl_shm_listener,
                                   data: *mut c_void
                                  ) -> c_int {
-    (WCH.wl_proxy_add_listener)(
+    ffi_dispatch!(WCH, wl_proxy_add_listener,
         shm as *mut wl_proxy,
         listener as *mut extern fn(),
         data
@@ -33,17 +38,17 @@ pub unsafe fn wl_shm_add_listener(shm: *mut wl_shm,
 
 #[inline(always)]
 pub unsafe fn wl_shm_set_user_data(shm: *mut wl_shm, data: *mut c_void) {
-    (WCH.wl_proxy_set_user_data)(shm as *mut wl_proxy, data)
+    ffi_dispatch!(WCH, wl_proxy_set_user_data,shm as *mut wl_proxy, data)
 }
 
 #[inline(always)]
 pub unsafe fn wl_shm_get_user_data(shm: *mut wl_shm) -> *mut c_void {
-    (WCH.wl_proxy_get_user_data)(shm as *mut wl_proxy)
+    ffi_dispatch!(WCH, wl_proxy_get_user_data,shm as *mut wl_proxy)
 }
 
 #[inline(always)]
 pub unsafe fn wl_shm_destroy(shm: *mut wl_shm) {
-    (WCH.wl_proxy_destroy)(shm as *mut wl_proxy)
+    ffi_dispatch!(WCH, wl_proxy_destroy,shm as *mut wl_proxy)
 }
 
 #[inline(always)]
@@ -51,10 +56,10 @@ pub unsafe fn wl_shm_create_pool(shm: *mut wl_shm,
                                  fd: int32_t,
                                  size: int32_t
                                 ) -> *mut wl_shm_pool {
-    (WCH.wl_proxy_marshal_constructor)(
+    ffi_dispatch!(WCH, wl_proxy_marshal_constructor,
         shm as *mut wl_proxy,
         WL_SHM_CREATE_POOL,
-        WCH.wl_shm_pool_interface,
+        ffi_dispatch_static!(WCH, wl_shm_pool_interface),
         ptr::null_mut::<c_void>(),
         fd,
         size

--- a/src/ffi/interfaces/shm_pool.rs
+++ b/src/ffi/interfaces/shm_pool.rs
@@ -3,6 +3,10 @@ use std::ptr;
 use libc::{c_void, int32_t, uint32_t};
 
 use ffi::abi::wl_proxy;
+#[cfg(not(feature = "dlopen"))]
+use ffi::abi::{wl_proxy_destroy, wl_proxy_set_user_data, wl_proxy_get_user_data,
+               wl_proxy_marshal, wl_proxy_marshal_constructor, wl_buffer_interface};
+#[cfg(feature = "dlopen")]
 use ffi::abi::WAYLAND_CLIENT_HANDLE as WCH;
 
 use super::buffer::wl_buffer;
@@ -15,12 +19,12 @@ const WL_SHM_POOL_RESIZE: uint32_t = 2;
 
 #[inline(always)]
 pub unsafe fn wl_shm_pool_set_user_data(shm_pool: *mut wl_shm_pool, data: *mut c_void) {
-    (WCH.wl_proxy_set_user_data)(shm_pool as *mut wl_proxy, data)
+    ffi_dispatch!(WCH, wl_proxy_set_user_data,shm_pool as *mut wl_proxy, data)
 }
 
 #[inline(always)]
 pub unsafe fn wl_shm_pool_get_user_data(shm_pool: *mut wl_shm_pool) -> *mut c_void {
-    (WCH.wl_proxy_get_user_data)(shm_pool as *mut wl_proxy)
+    ffi_dispatch!(WCH, wl_proxy_get_user_data,shm_pool as *mut wl_proxy)
 }
 
 #[inline(always)]
@@ -31,10 +35,10 @@ pub unsafe fn wl_shm_pool_create_buffer(shm_pool: *mut wl_shm_pool,
                                         stride: int32_t,
                                         format: uint32_t
                                        ) -> *mut wl_buffer {
-    (WCH.wl_proxy_marshal_constructor)(
+    ffi_dispatch!(WCH, wl_proxy_marshal_constructor,
         shm_pool as *mut wl_proxy,
         WL_SHM_POOL_CREATE_BUFFER,
-        WCH.wl_buffer_interface,
+        ffi_dispatch_static!(WCH, wl_buffer_interface),
         ptr::null_mut::<c_void>(),
         offset,
         width,
@@ -46,11 +50,11 @@ pub unsafe fn wl_shm_pool_create_buffer(shm_pool: *mut wl_shm_pool,
 
 #[inline(always)]
 pub unsafe fn wl_shm_pool_destroy(shm_pool: *mut wl_shm_pool) {
-    (WCH.wl_proxy_marshal)(shm_pool as *mut wl_proxy, WL_SHM_POOL_DESTROY);
-    (WCH.wl_proxy_destroy)(shm_pool as *mut wl_proxy)
+    ffi_dispatch!(WCH, wl_proxy_marshal,shm_pool as *mut wl_proxy, WL_SHM_POOL_DESTROY);
+    ffi_dispatch!(WCH, wl_proxy_destroy,shm_pool as *mut wl_proxy)
 }
 
 #[inline(always)]
 pub unsafe fn wl_shm_pool_resize(shm_pool: *mut wl_shm_pool, size: int32_t) {
-    (WCH.wl_proxy_marshal)(shm_pool as *mut wl_proxy, WL_SHM_POOL_RESIZE, size)
+    ffi_dispatch!(WCH, wl_proxy_marshal,shm_pool as *mut wl_proxy, WL_SHM_POOL_RESIZE, size)
 }

--- a/src/ffi/interfaces/subcompositor.rs
+++ b/src/ffi/interfaces/subcompositor.rs
@@ -3,6 +3,10 @@ use std::ptr;
 use libc::{c_void, uint32_t};
 
 use ffi::abi::wl_proxy;
+#[cfg(not(feature = "dlopen"))]
+use ffi::abi::{wl_proxy_destroy, wl_proxy_set_user_data, wl_proxy_get_user_data,
+               wl_proxy_marshal, wl_proxy_marshal_constructor, wl_subsurface_interface};
+#[cfg(feature = "dlopen")]
 use ffi::abi::WAYLAND_CLIENT_HANDLE as WCH;
 
 use super::subsurface::wl_subsurface;
@@ -15,18 +19,18 @@ const WL_SUBCOMPOSITOR_GET_SUBSURFACE: uint32_t = 1;
 
 #[inline(always)]
 pub unsafe fn wl_subcompositor_set_user_data(subcompositor: *mut wl_subcompositor, data: *mut c_void) {
-    (WCH.wl_proxy_set_user_data)(subcompositor as *mut wl_proxy, data)
+    ffi_dispatch!(WCH, wl_proxy_set_user_data,subcompositor as *mut wl_proxy, data)
 }
 
 #[inline(always)]
 pub unsafe fn wl_subcompositor_get_user_data(subcompositor: *mut wl_subcompositor) -> *mut c_void {
-    (WCH.wl_proxy_get_user_data)(subcompositor as *mut wl_proxy)
+    ffi_dispatch!(WCH, wl_proxy_get_user_data,subcompositor as *mut wl_proxy)
 }
 
 #[inline(always)]
 pub unsafe fn wl_subcompositor_destroy(subcompositor: *mut wl_subcompositor) {
-    (WCH.wl_proxy_marshal)(subcompositor as *mut wl_proxy, WL_SUBCOMPOSITOR_DESTROY);
-    (WCH.wl_proxy_destroy)(subcompositor as *mut wl_proxy)
+    ffi_dispatch!(WCH, wl_proxy_marshal,subcompositor as *mut wl_proxy, WL_SUBCOMPOSITOR_DESTROY);
+    ffi_dispatch!(WCH, wl_proxy_destroy,subcompositor as *mut wl_proxy)
 }
 
 #[inline(always)]
@@ -34,10 +38,10 @@ pub unsafe fn wl_subcompositor_get_subsurface(subcompositor: *mut wl_subcomposit
                                               surface: *mut wl_surface,
                                               parent: *mut wl_surface
                                              ) -> *mut wl_subsurface {
-    (WCH.wl_proxy_marshal_constructor)(
+    ffi_dispatch!(WCH, wl_proxy_marshal_constructor,
         subcompositor as *mut wl_proxy,
         WL_SUBCOMPOSITOR_GET_SUBSURFACE,
-        WCH.wl_subsurface_interface,
+        ffi_dispatch_static!(WCH,wl_subsurface_interface),
         ptr::null_mut::<c_void>(),
         surface,
         parent

--- a/src/ffi/interfaces/subsurface.rs
+++ b/src/ffi/interfaces/subsurface.rs
@@ -1,6 +1,10 @@
 use libc::{c_void, int32_t, uint32_t};
 
 use ffi::abi::wl_proxy;
+#[cfg(not(feature = "dlopen"))]
+use ffi::abi::{wl_proxy_destroy, wl_proxy_set_user_data, wl_proxy_get_user_data,
+               wl_proxy_marshal};
+#[cfg(feature = "dlopen")]
 use ffi::abi::WAYLAND_CLIENT_HANDLE as WCH;
 
 use super::surface::wl_surface;
@@ -16,41 +20,41 @@ const WL_SUBSURFACE_SET_DESYNC: uint32_t = 5;
 
 #[inline(always)]
 pub unsafe fn wl_subsurface_set_user_data(subsurface: *mut wl_subsurface, data: *mut c_void) {
-    (WCH.wl_proxy_set_user_data)(subsurface as *mut wl_proxy, data)
+    ffi_dispatch!(WCH, wl_proxy_set_user_data,subsurface as *mut wl_proxy, data)
 }
 
 #[inline(always)]
 pub unsafe fn wl_subsurface_get_user_data(subsurface: *mut wl_subsurface) -> *mut c_void {
-    (WCH.wl_proxy_get_user_data)(subsurface as *mut wl_proxy)
+    ffi_dispatch!(WCH, wl_proxy_get_user_data,subsurface as *mut wl_proxy)
 }
 
 #[inline(always)]
 pub unsafe fn wl_subsurface_destroy(subsurface: *mut wl_subsurface) {
-    (WCH.wl_proxy_marshal)(subsurface as *mut wl_proxy, WL_SUBSURFACE_DESTROY);
-    (WCH.wl_proxy_destroy)(subsurface as *mut wl_proxy)
+    ffi_dispatch!(WCH, wl_proxy_marshal,subsurface as *mut wl_proxy, WL_SUBSURFACE_DESTROY);
+    ffi_dispatch!(WCH, wl_proxy_destroy,subsurface as *mut wl_proxy)
 }
 
 #[inline(always)]
 pub unsafe fn wl_subsurface_set_position(subsurface: *mut wl_subsurface, x: int32_t, y: int32_t) {
-    (WCH.wl_proxy_marshal)(subsurface as *mut wl_proxy, WL_SUBSURFACE_SET_POSITION, x, y)
+    ffi_dispatch!(WCH, wl_proxy_marshal,subsurface as *mut wl_proxy, WL_SUBSURFACE_SET_POSITION, x, y)
 }
 
 #[inline(always)]
 pub unsafe fn wl_subsurface_place_above(subsurface: *mut wl_subsurface, sibling: *mut wl_surface) {
-    (WCH.wl_proxy_marshal)(subsurface as *mut wl_proxy, WL_SUBSURFACE_PLACE_ABOVE, sibling)
+    ffi_dispatch!(WCH, wl_proxy_marshal,subsurface as *mut wl_proxy, WL_SUBSURFACE_PLACE_ABOVE, sibling)
 }
 
 #[inline(always)]
 pub unsafe fn wl_subsurface_place_below(subsurface: *mut wl_subsurface, sibling: *mut wl_surface) {
-    (WCH.wl_proxy_marshal)(subsurface as *mut wl_proxy, WL_SUBSURFACE_PLACE_BELOW, sibling)
+    ffi_dispatch!(WCH, wl_proxy_marshal,subsurface as *mut wl_proxy, WL_SUBSURFACE_PLACE_BELOW, sibling)
 }
 
 #[inline(always)]
 pub unsafe fn wl_subsurface_set_sync(subsurface: *mut wl_subsurface) {
-    (WCH.wl_proxy_marshal)(subsurface as *mut wl_proxy, WL_SUBSURFACE_SET_SYNC)
+    ffi_dispatch!(WCH, wl_proxy_marshal,subsurface as *mut wl_proxy, WL_SUBSURFACE_SET_SYNC)
 }
 
 #[inline(always)]
 pub unsafe fn wl_subsurface_set_desync(subsurface: *mut wl_subsurface) {
-    (WCH.wl_proxy_marshal)(subsurface as *mut wl_proxy, WL_SUBSURFACE_SET_DESYNC)
+    ffi_dispatch!(WCH, wl_proxy_marshal,subsurface as *mut wl_proxy, WL_SUBSURFACE_SET_DESYNC)
 }

--- a/src/ffi/interfaces/surface.rs
+++ b/src/ffi/interfaces/surface.rs
@@ -3,6 +3,11 @@ use std::ptr;
 use libc::{c_int, c_void, int32_t, uint32_t};
 
 use ffi::abi::wl_proxy;
+#[cfg(not(feature = "dlopen"))]
+use ffi::abi::{wl_proxy_destroy, wl_proxy_add_listener, wl_proxy_set_user_data,
+               wl_proxy_get_user_data, wl_proxy_marshal, wl_proxy_marshal_constructor,
+               wl_callback_interface};
+#[cfg(feature = "dlopen")]
 use ffi::abi::WAYLAND_CLIENT_HANDLE as WCH;
 
 use super::buffer::wl_buffer;
@@ -39,7 +44,7 @@ pub unsafe fn wl_surface_add_listener(surface: *mut wl_surface,
                                       listener: *const wl_surface_listener,
                                       data: *mut c_void
                                      ) -> c_int {
-    (WCH.wl_proxy_add_listener)(
+    ffi_dispatch!(WCH, wl_proxy_add_listener,
         surface as *mut wl_proxy,
         listener as *mut extern fn(),
         data
@@ -48,18 +53,18 @@ pub unsafe fn wl_surface_add_listener(surface: *mut wl_surface,
 
 #[inline(always)]
 pub unsafe fn wl_surface_set_user_data(surface: *mut wl_surface, data: *mut c_void) {
-    (WCH.wl_proxy_set_user_data)(surface as *mut wl_proxy, data)
+    ffi_dispatch!(WCH, wl_proxy_set_user_data,surface as *mut wl_proxy, data)
 }
 
 #[inline(always)]
 pub unsafe fn wl_surface_get_user_data(surface: *mut wl_surface) -> *mut c_void {
-    (WCH.wl_proxy_get_user_data)(surface as *mut wl_proxy)
+    ffi_dispatch!(WCH, wl_proxy_get_user_data,surface as *mut wl_proxy)
 }
 
 #[inline(always)]
 pub unsafe fn wl_surface_destroy(surface: *mut wl_surface) {
-    (WCH.wl_proxy_marshal)(surface as *mut wl_proxy, WL_SURFACE_DESTROY);
-    (WCH.wl_proxy_destroy)(surface as *mut wl_proxy)
+    ffi_dispatch!(WCH, wl_proxy_marshal,surface as *mut wl_proxy, WL_SURFACE_DESTROY);
+    ffi_dispatch!(WCH, wl_proxy_destroy,surface as *mut wl_proxy)
 }
 
 #[inline(always)]
@@ -68,7 +73,7 @@ pub unsafe fn wl_surface_attach(surface: *mut wl_surface,
                                 x: int32_t,
                                 y: int32_t
                                ) {
-    (WCH.wl_proxy_marshal)(
+    ffi_dispatch!(WCH, wl_proxy_marshal,
         surface as *mut wl_proxy,
         WL_SURFACE_ATTACH,
         buffer,
@@ -84,7 +89,7 @@ pub unsafe fn wl_surface_damage(surface: *mut wl_surface,
                                 width: int32_t,
                                 height: int32_t
                                ) {
-    (WCH.wl_proxy_marshal)(
+    ffi_dispatch!(WCH, wl_proxy_marshal,
         surface as *mut wl_proxy,
         WL_SURFACE_DAMAGE,
         x,
@@ -96,35 +101,36 @@ pub unsafe fn wl_surface_damage(surface: *mut wl_surface,
 
 #[inline(always)]
 pub unsafe fn wl_surface_frame(surface: *mut wl_surface) -> *mut wl_callback {
-    (WCH.wl_proxy_marshal_constructor)(
+    ffi_dispatch!(WCH, wl_proxy_marshal_constructor,
         surface as *mut wl_proxy,
         WL_SURFACE_FRAME,
-        WCH.wl_callback_interface,
+        ffi_dispatch_static!(WCH, wl_callback_interface),
         ptr::null_mut::<c_void>()
     ) as *mut wl_callback
 }
 
+
 #[inline(always)]
 pub unsafe fn wl_surface_set_opaque_region(surface: *mut wl_surface, region: *mut wl_region) {
-    (WCH.wl_proxy_marshal)(surface as *mut wl_proxy, WL_SURFACE_SET_OPAQUE_REGION, region)
+    ffi_dispatch!(WCH, wl_proxy_marshal,surface as *mut wl_proxy, WL_SURFACE_SET_OPAQUE_REGION, region)
 }
 
 #[inline(always)]
 pub unsafe fn wl_surface_set_input_region(surface: *mut wl_surface, region: *mut wl_region) {
-    (WCH.wl_proxy_marshal)(surface as *mut wl_proxy, WL_SURFACE_SET_INPUT_REGION, region)
+    ffi_dispatch!(WCH, wl_proxy_marshal,surface as *mut wl_proxy, WL_SURFACE_SET_INPUT_REGION, region)
 }
 
 #[inline(always)]
 pub unsafe fn wl_surface_commit(surface: *mut wl_surface) {
-    (WCH.wl_proxy_marshal)(surface as *mut wl_proxy, WL_SURFACE_COMMIT)
+    ffi_dispatch!(WCH, wl_proxy_marshal,surface as *mut wl_proxy, WL_SURFACE_COMMIT)
 }
 
 #[inline(always)]
 pub unsafe fn wl_surface_set_buffer_transform(surface: *mut wl_surface, transform: int32_t) {
-    (WCH.wl_proxy_marshal)(surface as *mut wl_proxy, WL_SURFACE_SET_BUFFER_TRANSFORM, transform)
+    ffi_dispatch!(WCH, wl_proxy_marshal,surface as *mut wl_proxy, WL_SURFACE_SET_BUFFER_TRANSFORM, transform)
 }
 
 #[inline(always)]
 pub unsafe fn wl_surface_set_buffer_scale(surface: *mut wl_surface, scale: int32_t) {
-    (WCH.wl_proxy_marshal)(surface as *mut wl_proxy, WL_SURFACE_SET_BUFFER_SCALE, scale)
+    ffi_dispatch!(WCH, wl_proxy_marshal,surface as *mut wl_proxy, WL_SURFACE_SET_BUFFER_SCALE, scale)
 }

--- a/src/ffi/interfaces/touch.rs
+++ b/src/ffi/interfaces/touch.rs
@@ -1,6 +1,10 @@
 use libc::{c_int, c_void, uint32_t, int32_t};
 
 use ffi::abi::{wl_proxy, wl_fixed_t};
+#[cfg(not(feature = "dlopen"))]
+use ffi::abi::{wl_proxy_destroy, wl_proxy_add_listener, wl_proxy_set_user_data,
+               wl_proxy_get_user_data, wl_proxy_marshal};
+#[cfg(feature = "dlopen")]
 use ffi::abi::WAYLAND_CLIENT_HANDLE as WCH;
 
 use super::surface::wl_surface;
@@ -42,7 +46,7 @@ pub unsafe fn wl_touch_add_listener(touch: *mut wl_touch,
                                     listener: *const wl_touch_listener,
                                     data: *mut c_void
                                    ) -> c_int {
-    (WCH.wl_proxy_add_listener)(
+    ffi_dispatch!(WCH, wl_proxy_add_listener,
         touch as *mut wl_proxy,
         listener as *mut extern fn(),
         data
@@ -51,21 +55,21 @@ pub unsafe fn wl_touch_add_listener(touch: *mut wl_touch,
 
 #[inline(always)]
 pub unsafe fn wl_touch_set_user_data(touch: *mut wl_touch, data: *mut c_void) {
-    (WCH.wl_proxy_set_user_data)(touch as *mut wl_proxy, data)
+    ffi_dispatch!(WCH, wl_proxy_set_user_data,touch as *mut wl_proxy, data)
 }
 
 #[inline(always)]
 pub unsafe fn wl_touch_get_user_data(touch: *mut wl_touch) -> *mut c_void {
-    (WCH.wl_proxy_get_user_data)(touch as *mut wl_proxy)
+    ffi_dispatch!(WCH, wl_proxy_get_user_data,touch as *mut wl_proxy)
 }
 
 #[inline(always)]
 pub unsafe fn wl_touch_destroy(touch: *mut wl_touch) {
-    (WCH.wl_proxy_destroy)(touch as *mut wl_proxy)
+    ffi_dispatch!(WCH, wl_proxy_destroy,touch as *mut wl_proxy)
 }
 
 #[inline(always)]
 pub unsafe fn wl_touch_release(touch: *mut wl_touch) {
-    (WCH.wl_proxy_marshal)(touch as *mut wl_proxy, WL_TOUCH_RELEASE);
-    (WCH.wl_proxy_destroy)(touch as *mut wl_proxy)
+    ffi_dispatch!(WCH, wl_proxy_marshal,touch as *mut wl_proxy, WL_TOUCH_RELEASE);
+    ffi_dispatch!(WCH, wl_proxy_destroy,touch as *mut wl_proxy)
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -15,6 +15,11 @@
 //! - module `egl`: it provides a mean to build EGL surfaces in a wayland context. It requires
 //!   the presence of `libwayland-egl.so`. This module is activated by the `egl` feature.
 //!
+//! Additionnaly, the feature `dlopen` prevents the crate to be linked to the various
+//! wayland libraries. In this case, it will instead try to load them dynamically at runtime.
+//! In this case, each module will provide a function allowing you to gracefully check if
+//! the load was successful. There is also the function `is_wayland_lib_available()` at the
+//! root of this crate, providing the same function for the core `libwayland-client.so`.
 
 #[macro_use] extern crate bitflags;
 #[macro_use] extern crate lazy_static;
@@ -33,7 +38,10 @@ pub mod internals {
     pub use ffi::{FFI, Bind};
 }
 
+#[cfg(feature = "dlopen")]
 /// Returns whether the library `libwayland-client.so` has been found and could be loaded.
+///
+/// This function is present only if the feature `dlopen` is activated
 pub fn is_wayland_lib_available() -> bool {
     ffi::abi::WAYLAND_CLIENT_OPTION.is_some()
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -13,7 +13,7 @@
 //! a system library which they will try to load at first use.
 //!
 //! - module `egl`: it provides a mean to build EGL surfaces in a wayland context. It requires
-//!   the presence of `libwayland-egl.so`.
+//!   the presence of `libwayland-egl.so`. This module is activated by the `egl` feature.
 //!
 
 #[macro_use] extern crate bitflags;
@@ -23,6 +23,8 @@ extern crate libc;
 #[macro_use] mod ffi;
 
 pub mod core;
+
+#[cfg(feature = "egl")]
 pub mod egl;
 
 pub mod internals {

--- a/update-docs.sh
+++ b/update-docs.sh
@@ -1,0 +1,49 @@
+#!/bin/bash
+set -e
+DOC_BRANCH="gh-pages"
+
+[[ "$(git symbolic-ref --short HEAD)" == "master" ]] || exit 0
+
+msg() {
+    echo "[1;34m> [1;32m$@[0m"
+}
+
+dir="$(pwd)"
+last_rev="$(git rev-parse HEAD)"
+last_msg="$(git log -1 --pretty=%B)"
+
+msg "Cloning into a temporary directory..."
+# The second call is to support OSX.
+tmp="$(mktemp -d 2>/dev/null || mktemp -d -t 'tmp-rust-docs')"
+trap "cd \"$dir\"; rm -rf \"$tmp\"" EXIT
+git clone -qb master "$dir" "$tmp"
+
+cd "$tmp"
+ln -s "$dir/target" "$tmp/target"
+
+msg "Generating documentation..."
+cargo doc --no-deps
+
+# Switch to pages
+msg "Replacing documentation..."
+if ! git checkout -q "$DOC_BRANCH" 2>/dev/null; then
+    git checkout -q --orphan "$DOC_BRANCH"
+    git rm -q --ignore-unmatch -rf .
+    cat > .gitignore <<EOF
+/target/
+/Cargo.lock
+EOF
+    git add .gitignore
+    git commit -m "Initial commit."
+fi
+
+# Clean and replace
+git rm -q --ignore-unmatch -rf .
+git reset -q -- .gitignore
+git checkout -q -- .gitignore
+cp -a target/doc/* .
+rm target
+git add .
+git commit -m "Update docs for $last_rev" -m "$last_msg"
+git push -qu origin "$DOC_BRANCH"
+msg "Done."


### PR DESCRIPTION
Move the `egl` module behind a cargo feature.

Add a feature `dlopen` disabling dynamic linking and forcing the use of `dlopen(..)` to find the libraries. It must be this way (and not a feature `dylink`) because moving from dynamic linking to dlopen is not breaking, while the opposite is.

Plus some cleanup.