### PR TITLE
wl-sys: Update to libc-0.2 and dlib-0.2.

### DIFF
--- a/wayland-sys/Cargo.toml
+++ b/wayland-sys/Cargo.toml
@@ -1,14 +1,14 @@
 [package]
 name = "wayland-sys"
-version = "0.1.0"
+version = "0.2.0"
 repository = "https://github.com/vberger/wayland-client-rs"
 authors = ["Victor Berger <victor.berger@m4x.org>"]
 description = "FFI bindings to the various libwayland-*.so libraries. You should only need this crate if you are working on custom wayland protocol extensions. Look at the crate wayland-client for usable bindings."
 license = "MIT"
 
 [dependencies]
-dlib = "0.1"
-libc = "0.1"
+dlib = "0.2"
+libc = "0.2"
 lazy_static = { version = "0.1", optional = true }
 
 [features]

--- a/wayland-sys/src/client.rs
+++ b/wayland-sys/src/client.rs
@@ -2,7 +2,7 @@
 //!
 //! The generated handle is named `WAYLAND_CLIENT_HANDLE`
 
-use libc::{c_char, c_void, c_int, size_t, uint32_t};
+use {c_char, c_void, c_int, size_t, uint32_t};
 
 use super::common::*;
 

--- a/wayland-sys/src/common.rs
+++ b/wayland-sys/src/common.rs
@@ -1,7 +1,7 @@
 //! Various types and functions that are used by both the client and the server
 //! libraries.
 
-use libc::{c_char, c_void, c_int, size_t};
+use {c_char, c_void, c_int, size_t};
 
 #[repr(C)]
 pub struct wl_message {

--- a/wayland-sys/src/egl.rs
+++ b/wayland-sys/src/egl.rs
@@ -4,7 +4,7 @@
 //!
 //! The created handle is named `WAYLAND_EGl_HANDLE`.
 
-use libc::c_int;
+use c_int;
 use client::wl_proxy;
 
 pub enum wl_egl_window { }

--- a/wayland-sys/src/lib.rs
+++ b/wayland-sys/src/lib.rs
@@ -49,6 +49,8 @@ pub mod client;
 #[cfg(all(feature = "egl", feature = "client"))]
 pub mod egl;
 
+pub use libc::{c_char, c_void, c_int, size_t, uint32_t};
+
 // Small hack while #[macro_reexport] is not stable
 
 #[cfg(feature = "dlopen")]


### PR DESCRIPTION
And reexport the C types used by the library, to future-proof things.