### PR TITLE
WIP: replace libc with std::os::raw

### DIFF
--- a/scanner/src/client_gen.rs
+++ b/scanner/src/client_gen.rs
@@ -21,7 +21,7 @@ pub fn generate_client_api<O: Write>(protocol: Protocol, out: &mut O) {
     writeln!(out, "use std::ptr;").unwrap();
     writeln!(out, "use std::sync::Arc;").unwrap();
     writeln!(out, "use std::sync::atomic::{{AtomicBool, Ordering}};").unwrap();
-    writeln!(out, "use libc::{{c_void, c_char}};").unwrap();
+    writeln!(out, "use std::os::raw::{{c_void, c_char}};").unwrap();
 
     // envent handling
 

--- a/scanner/src/interface_gen.rs
+++ b/scanner/src/interface_gen.rs
@@ -22,7 +22,7 @@ pub fn generate_interfaces<O: Write>(protocol: Protocol, out: &mut O) {
     }
 
     writeln!(out, "use wayland_sys::common::*;\n").unwrap();
-    writeln!(out, "use libc::{{c_void, c_char}};\n").unwrap();
+    writeln!(out, "use std::os::raw::{{c_void, c_char}};\n").unwrap();
 
     //
     // null types array

--- a/wayland-client/Cargo.toml
+++ b/wayland-client/Cargo.toml
@@ -11,12 +11,12 @@ build = "build.rs"
 [dependencies]
 crossbeam = "0.1.5"
 dlib = "0.1"
-libc = "0.1"
 lazy_static = { version = "0.1", optional = true }
 wayland-sys = { version = "0.1", features = ["client"] }
 
-[build-dependencies]
-wayland-scanner = "0.1"
+[build-dependencies.wayland-scanner]
+version = "0.1"
+path = "../scanner"
 
 [dev-dependencies]
 byteorder = "0.3"

--- a/wayland-client/src/egl.rs
+++ b/wayland-client/src/egl.rs
@@ -1,4 +1,4 @@
-use libc::c_void;
+use std::os::raw::c_void;
 use std::ops::Deref;
 
 use wayland_sys::egl::*;

--- a/wayland-client/src/lib.rs
+++ b/wayland-client/src/lib.rs
@@ -3,8 +3,6 @@ extern crate crossbeam;
 #[macro_use]
 extern crate dlib;
 
-extern crate libc;
-
 extern crate wayland_sys;
 
 mod events;

--- a/wayland-sys/Cargo.toml
+++ b/wayland-sys/Cargo.toml
@@ -8,7 +8,6 @@ license = "MIT"
 
 [dependencies]
 dlib = "0.2"
-libc = "0.2"
 lazy_static = { version = "0.1", optional = true }
 
 [features]

--- a/wayland-sys/src/common.rs
+++ b/wayland-sys/src/common.rs
@@ -1,7 +1,7 @@
 //! Various types and functions that are used by both the client and the server
 //! libraries.
 
-use {c_char, c_void, c_int, size_t};
+use std::os::raw::{c_char, c_void, c_int};
 
 #[repr(C)]
 pub struct wl_message {
@@ -28,8 +28,8 @@ pub struct wl_list {
 
 #[repr(C)]
 pub struct wl_array {
-    pub size: size_t,
-    pub alloc: size_t,
+    pub size: usize,
+    pub alloc: usize,
     pub data: *mut c_void
 }
 
@@ -54,7 +54,7 @@ pub fn wl_fixed_from_int(i: i32) -> wl_fixed_t {
 // must be the appropriate size
 // can contain i32, u32 and pointers
 #[repr(C)]
-pub struct wl_argument { _f: size_t }
+pub struct wl_argument { _f: usize }
 
 pub type wl_dispatcher_func_t = extern "C" fn(*const c_void, *mut c_void, u32, *const wl_message, *const wl_argument);
 pub type wl_log_func_t = extern "C" fn(*const c_char, ...);

--- a/wayland-sys/src/lib.rs
+++ b/wayland-sys/src/lib.rs
@@ -39,8 +39,6 @@ extern crate dlib;
 #[macro_use]
 extern crate lazy_static;
 
-extern crate libc;
-
 pub mod common;
 
 #[cfg(feature = "client")]
@@ -48,8 +46,6 @@ pub mod client;
 
 #[cfg(all(feature = "egl", feature = "client"))]
 pub mod egl;
-
-pub use libc::{c_char, c_void, c_int, size_t, uint32_t};
 
 // Small hack while #[macro_reexport] is not stable
 


### PR DESCRIPTION
This doesn’t work yet. I’m getting errors like:

```
 expected `*mut libc::types::common::c95::c_void`,
    found `*mut std::os::raw::c_void`
```

I think one of the dependencies is still using libc, but at this point it’s one yak too many to shave for me right now :) Feel free to take this up or disregard it.